### PR TITLE
Plyr dependency

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,1 +1,2 @@
 exportPattern("^[[:alpha:]]+")
+import(plyr)

--- a/R/netintel.R
+++ b/R/netintel.R
@@ -72,7 +72,7 @@ BulkOrigin <- function(ip.list,host="v4.whois.cymru.com",port=43) {
 
   # trim header, split fields and convert results
   response = response[2:length(response)]
-  response = laply(response,.fun=function(n) {
+  response = lapply(response,.fun=function(n) {
     sapply(strsplit(n,"|",fixed=TRUE),trim)
   })
   response = adply(response,c(1))
@@ -115,7 +115,7 @@ BulkPeer <- function(ip.list,host="v4-peer.whois.cymru.com",port=43) {
   
   # trim header, split fields and convert results
   response = response[2:length(response)]
-  response = laply(response,function(n) {
+  response = lapply(response,function(n) {
     sapply(strsplit(n,"|",fixed=TRUE),trim)
   })  
   response = adply(response,c(1))
@@ -158,7 +158,7 @@ BulkOriginASN <- function(asn.list,host="v4.whois.cymru.com",port=43) {
   # trim header, split fields and convert results
   
   response = response[2:length(response)]
-  response = laply(response,.fun=function(n) {
+  response = lapply(response,.fun=function(n) {
     sapply(strsplit(n,"|",fixed=TRUE),trim)
   })
 


### PR DESCRIPTION
While the netintel.R file has a library(plyr) line, this import is not in the NAMESPACE file (which supersedes the Depends line in the DESCRIPTION file). This change puts plyr import into NAMESPACE, keeping the lords of CRAN and R style mollified. :wink: 

Note this depends on the lapply-fix branch being applied. Probably should have broken these fixes up better...
